### PR TITLE
Direction calculation if no value is recieved from the sensor

### DIFF
--- a/src/radar_publisher.cpp
+++ b/src/radar_publisher.cpp
@@ -156,7 +156,7 @@ void process_json(radar_omnipresense::radar_data *data, std::vector<std::string>
             else
                 data->speed = atof(speed->valuestring);
 
-            if (data->speed >= 0)
+            if (data->speed > 0)
             data->direction = "inbound";
             else if (data->speed == 0)
             data->direction = "still";


### PR DESCRIPTION
Probably a totally unnecessary fix, but i stumbled over it while reading the code.

In the check if a target is inbound, standstill or outbound, standstill was an unreachable case, because the inbound case included speed == 0.

